### PR TITLE
Actualización r-info 2022

### DIFF
--- a/snippets.json
+++ b/snippets.json
@@ -1,9 +1,23 @@
 {
-	"Estrucura Base": {
-		"prefix": "programa",
-		"body": [
-            "programa nombrePrograma\nareas\n\tciudad: AreaC (1,1,100,100)\nrobots\n\trobot robot1\ncomenzar\n\t$1\nfin\nvariables\n\tRinfo: robot1\ncomenzar\n\tAsignarArea (Rinfo,ciudad)\nIniciar (Rinfo,1,1)\nfin", "$2"
-		],
-		"description": "estructura basica de un programa"
-	}
+  "Estrucura Base": {
+    "prefix": "programa",
+    "body": [
+      "programa ${1:nombrePrograma}",
+      "areas",
+      "  ciudad: AreaC(1,1,100,100)",
+      "robots",
+      "  robot robot1",
+      "  comenzar",
+      "    $2",
+      "  fin",
+      "variables",
+      "  Rinfo: robot1",
+      "comenzar",
+      "  AsignarArea(Rinfo,ciudad)",
+      "  Iniciar(Rinfo,1,1)",
+      "fin",
+      ""
+    ],
+    "description": "estructura basica de un programa"
+  }
 }

--- a/syntaxes/ri.tmLanguage.json
+++ b/syntaxes/ri.tmLanguage.json
@@ -17,15 +17,15 @@
 			"patterns": [
 				{
 					"name": "keyword.control.ri",
-					"match": "\\b(si|mientras|repetir)\\b"
+					"match": "\\b(si|sino|mientras|repetir)\\b"
 				},
 				{
 					"name": "keyword.other.ri",
-					"match": "\\b(programa|robots|areas|variables|comenzar|fin)\\b"
+					"match": "\\b(programa|procesos|proceso|robots|areas|variables|comenzar|fin)\\b"
 				},
 				{
 					"name": "support.function.other.ri",
-					"match": "\\b(tomarFlor|HayFlorEnLaBolsa|HayFlorEnLaEsquina|depositarFlor|HayPapelEnLaBolsa|HayPapelEnLaEsquina|tomarPapel|depositarPapel)\\b"
+					"match": "\\b(tomarFlor|HayFlorEnLaBolsa|HayFlorEnLaEsquina|depositarFlor|HayPapelEnLaBolsa|HayPapelEnLaEsquina|tomarPapel|depositarPapel|PosCa|PosAv)\\b"
 				}
 			]
 		},
@@ -74,7 +74,7 @@
 			"patterns": [
 				{
 					"name": "constant.language.ri",
-					"match": "\\b(verdadero|falso|boolean|numero)\\b"
+					"match": "\\b(V|F|boolean|numero)\\b"
 				}
 			]
 		},

--- a/syntaxes/ri.tmLanguage.json
+++ b/syntaxes/ri.tmLanguage.json
@@ -24,8 +24,12 @@
 					"match": "\\b(programa|procesos|proceso|robots|robot|areas|variables|comenzar|fin)\\b"
 				},
 				{
-					"name": "support.function.other.ri",
-					"match": "\\b(tomarFlor|HayFlorEnLaBolsa|HayFlorEnLaEsquina|depositarFlor|HayPapelEnLaBolsa|HayPapelEnLaEsquina|tomarPapel|depositarPapel|PosCa|PosAv)\\b"
+					"name": "variable.other.ri",
+					"match": "\\b(mover|derecha|tomarFlor|depositarFlor|tomarPapel|depositarPapel)\\b"
+				},
+				{
+					"name": "support.function.ri",
+					"match": "\\b(HayFlorEnLaBolsa|HayFlorEnLaEsquina|HayPapelEnLaBolsa|HayPapelEnLaEsquina|PosCa|PosAv)\\b"
 				}
 			]
 		},
@@ -45,7 +49,7 @@
 					"name":"keyword.operator.assign.ri"
 				},{
 					"match": "(&|~)",
-					"name": "support.function.logical.ri"
+					"name": "keyword.operator.logical.ri"
 				}
 			]
 		},

--- a/syntaxes/ri.tmLanguage.json
+++ b/syntaxes/ri.tmLanguage.json
@@ -21,7 +21,7 @@
 				},
 				{
 					"name": "keyword.other.ri",
-					"match": "\\b(programa|procesos|proceso|robots|areas|variables|comenzar|fin)\\b"
+					"match": "\\b(programa|procesos|proceso|robots|robot|areas|variables|comenzar|fin)\\b"
 				},
 				{
 					"name": "support.function.other.ri",


### PR DESCRIPTION
### Palabras añadidas
- `sino`
- `proceso`
- `procesos`
- `PosCa`
- `PosAv`
- `robot`
- `mover`
- `derecha`

### Otros
- Se reemplazó `verdadero` y `falso` por `V` y `F` respectivamente
- Se cambió algunos patterns para que no tengan el mismo color
- Se arregló el snippet `programa` para que tenga la identación adecuada